### PR TITLE
Some fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+.DS_Store
 template/objects/
 template/objects/**
 template/dict.xml
-output/dict.json
+output/dict*
 node_modules
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -65,7 +65,8 @@ function replaceEntities(string) {
 
 function replaceVarious(string) {
   // Remove comments
-  string = string.replace(/<\!--.*?-->/g, '');
+  string = string.replace(/<!--.*?-->/g, '');
+  string = string.replace(/<!--/g, '');
 
   // Nicer long dashes
   string = string.replace(/--/g, '–');

--- a/template/Makefile
+++ b/template/Makefile
@@ -22,7 +22,7 @@ DICT_BUILD_OPTS		=
 # The DICT_BUILD_TOOL_DIR value is used also in "build_dict.sh" script.
 # You need to set it when you invoke the script directly.
 
-DICT_BUILD_TOOL_DIR	=	"/Applications/Utilities/DictionaryDevelopmentKit"
+DICT_BUILD_TOOL_DIR	=	"/Applications/Utilities/Dictionary Development Kit"
 DICT_BUILD_TOOL_BIN	=	"$(DICT_BUILD_TOOL_DIR)/bin"
 
 ###########################

--- a/template/styles.css
+++ b/template/styles.css
@@ -139,3 +139,18 @@ div {
         font-feature-settings: 'smcp';
     }
 }
+
+html {
+  /* There is a style="background: white" on the html element we have to beat */
+  background: none !important;
+}
+
+@media (prefers-dark-interface) {
+  .hw {
+    /* blue is more readable on the dark background than maroon */
+    color: -webkit-link;
+  }
+  img {
+    filter: invert(100%);
+  }
+}


### PR DESCRIPTION
* Ignore more stuff that will appear dirty when run
* Support dark mode in the CSS
* The directory of the Dictionary Development Kit has spaces in the [latest download](https://download.developer.apple.com/Developer_Tools/Additional_Tools_for_Xcode_11/Additional_Tools_for_Xcode_11.dmg)
* Escaping the `!` looking for comments produces invalid xml (tested with `xmllint --noout template/dict.xml`)
  * Some invalid comments seem to have been introduced