### PR TITLE
Release only the Apple Dictionary package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: Build
 
 on:
   - push
+  - pull_request
 
 jobs:
   lint:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Package dictionary
         run: cd template && make
       - name: Zip up dictionary
-        run: zip -r9 websters-1913-dictionary.zip './objects'
+        run: zip -r9 websters-1913-dictionary.zip './objects/Webster’s 1913.dictionary'
       - name: Upload dictionary archive
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
This avoids zipping up the entire `template/objects/` directory, when we only need the `.dictionary` package.