### PR TITLE
Bug fixes for Webster entry detection

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -252,14 +252,15 @@ function parseFile (file: string) {
     if (ONLYWEBSTER) {
       let src;
       let p = el;
-      while (!src) {
+      while (!src || src.length == 0) {
         src = p.find('source');
         p = p.next();
+        if (p.length == 0) {
+          break;
+        }
       }
 
-      if (src.text().trim() !== '1913 Webster' &&
-        src.text().trim() !== 'Webster 1913 Suppl.'
-      ) {
+      if (!src.text().includes('1913')) {
         return true;
       }
 

--- a/index.ts
+++ b/index.ts
@@ -260,7 +260,9 @@ function parseFile (file: string) {
         }
       }
 
-      if (!src.text().includes('1913')) {
+      if (src.text().trim() !== '1913 Webster' &&
+        src.text().trim() !== 'Webster 1913 Suppl.'
+      ) {
         return true;
       }
 


### PR DESCRIPTION
* Using `!src` by itself seems insufficient since `.find` always returns a valid (i.e. non-null) JS object; you must further check that it contains the relevant tag
* The match list excluded the "1913 Webster + PJC" source.